### PR TITLE
Fixed puppet-check on 101 - 2.0

### DIFF
--- a/pe-deploy-and-discover-lab-2-0/install-pe-agents/check-puppet
+++ b/pe-deploy-and-discover-lab-2-0/install-pe-agents/check-puppet
@@ -1,16 +1,15 @@
 #!/bin/bash
 
+EXIT_CODE=0
+
 if [ "$(puppet query 'nodes { certname ~ "nixagent" }' --urls http://localhost:8080 | jq -r .[])" != '' ]; then
-  LINUX_AGENT=1
+  fail-message "Linux agent has not been installed or its certificte has not been signed"
+  EXIT_CODE=1
 fi
 
 if [ "$(puppet query 'nodes { certname ~ "winagent" }' --urls http://localhost:8080 | jq -r .[])" != '' ]; then
-  WINDOWS_AGENT=1
+  fail-message "Windows agent has not been installed or its certificte has not been signed"
+  EXIT_CODE=1
 fi
 
-if [ "${LINUX_AGENT}" -o "${WINDOWS_AGENT}" ]; then
-  exit 0
-else
-  fail-message "Neither the Linux nor the Windows agent has been installed"
-  exit 1
-fi
+exit $EXIT_CODE

--- a/pe-deploy-and-discover-lab-2-0/install-pe-agents/check-puppet
+++ b/pe-deploy-and-discover-lab-2-0/install-pe-agents/check-puppet
@@ -2,12 +2,12 @@
 
 EXIT_CODE=0
 
-if [ "$(puppet query 'nodes { certname ~ "nixagent" }' --urls http://localhost:8080 | jq -r .[])" != '' ]; then
+if [ "$(puppet query 'nodes { certname ~ "nixagent" }' --urls http://localhost:8080 | jq -r .[])" == '' ]; then
   fail-message "Linux agent has not been installed or its certificte has not been signed"
   EXIT_CODE=1
 fi
 
-if [ "$(puppet query 'nodes { certname ~ "winagent" }' --urls http://localhost:8080 | jq -r .[])" != '' ]; then
+if [ "$(puppet query 'nodes { certname ~ "winagent" }' --urls http://localhost:8080 | jq -r .[])" == '' ]; then
   fail-message "Windows agent has not been installed or its certificte has not been signed"
   EXIT_CODE=1
 fi


### PR DESCRIPTION
At the time of submitting this MR the lab doesn't correctly check if lab2.0 has been done correctly (tried to finish with Linux installed and windows not and got no errors).
I'm not sure if the current check-puppet on GitHub has been pushed to Instruqt. If yes, then the current check is not correct and this should fix it. If not, then this MR can be ignored.
Also are added different messages according to what agent is missing. 
(Couldn't test the script on a real lab node)